### PR TITLE
Fix unitialized _nesting_level on new event-loop instances.

### DIFF
--- a/nest_asyncio.py
+++ b/nest_asyncio.py
@@ -109,7 +109,7 @@ def _patch_loop(loop):
     cls = loop.__class__
     cls._run_until_complete_orig = cls.run_until_complete
     cls.run_until_complete = run_until_complete
-    loop._nesting_level = 0
+    cls._nesting_level = 0
 
 
 def _patch_task():

--- a/tests/nest_test.py
+++ b/tests/nest_test.py
@@ -8,50 +8,53 @@ def exception_handler(loop, context):
     print('Exception:', context)
 
 
-loop = asyncio.get_event_loop()
-asyncio.set_event_loop(loop)
-loop.set_debug(True)
-loop.set_exception_handler(exception_handler)
-
-
 class NestTest(unittest.TestCase):
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+        self.loop.set_debug(True)
+        self.loop.set_exception_handler(exception_handler)
+
+    def tearDown(self):
+        self.loop.stop()
+        del self.loop
 
     async def coro(self):
         await asyncio.sleep(0.01)
         return 42
 
     async def coro2(self):
-        result = loop.run_until_complete(self.coro())
+        result = self.loop.run_until_complete(self.coro())
         self.assertEqual(result, await self.coro())
         return result
 
     async def coro3(self):
-        result = loop.run_until_complete(self.coro2())
+        result = self.loop.run_until_complete(self.coro2())
         self.assertEqual(result, await self.coro2())
         return result
 
     def test_nesting(self):
-        result = loop.run_until_complete(self.coro3())
+        result = self.loop.run_until_complete(self.coro3())
         self.assertEqual(result, 42)
 
     async def ensure_future_with_run_until_complete(self):
         task = asyncio.ensure_future(self.coro())
-        return loop.run_until_complete(task)
+        return self.loop.run_until_complete(task)
 
     def test_ensure_future_with_run_until_complete(self):
-        result = loop.run_until_complete(
+        result = self.loop.run_until_complete(
             self.ensure_future_with_run_until_complete())
         self.assertEqual(result, 42)
 
     async def ensure_future_with_run_until_complete_with_wait(self):
         task = asyncio.ensure_future(self.coro())
-        done, pending = loop.run_until_complete(
+        done, pending = self.loop.run_until_complete(
             asyncio.wait([task], return_when=asyncio.ALL_COMPLETED))
         task = done.pop()
         return task.result()
 
     def test_ensure_future_with_run_until_complete_with_wait(self):
-        result = loop.run_until_complete(
+        result = self.loop.run_until_complete(
             self.ensure_future_with_run_until_complete_with_wait())
         self.assertEqual(result, 42)
 


### PR DESCRIPTION
We currently monkey-patch class methods on the event loop, and check for
the existence of our monkey patches when deciding whether or not to
(re-)install them.  However, our implementation also depends on an
instance variable _nesting_level which is only instantiated on the
event-loop instance currently being patched.

This patch makes _nesting_level a class variable, effectively making all
new event-loop instances start with an initial _nesting_level of 0.