### PR TITLE
Include license and tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+recursive-include test *.py


### PR DESCRIPTION
Related to https://github.com/erdewit/nest_asyncio/issues/13#issuecomment-568501959

As a continuation for the kind changes at eb0c057b1dd1c9923d10171d0fcd9858e5ab2a1f, this PR suggests adding a `MANIFEST.in` file so the `LICENSE` file is included in the generated `.tar.gz`, along with the `tests/` folder (this was not mentioned in the comment, but I included them as well for easing packaging efforts).

The goal is to be able to retrieve everything a packager needs just from the source distribution file, as a "wishlist" suggestion coming from an effort for packaging `nest_asyncio` into debian.