### PR TITLE
Fix tests inclusion directive in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include LICENSE
-recursive-include test *.py
+recursive-include tests *.py


### PR DESCRIPTION
During #15, I mistakenly introduced a reference to a `test` directory that should have been `tests` (with the extra `s`), which defeated the purposed of including the test files in the source distribution. This PR attempts to fix it - apologies for the extra noise!