### PR TITLE
fix: running loop should be inset after run_until_complete

### DIFF
--- a/nest_asyncio.py
+++ b/nest_asyncio.py
@@ -47,16 +47,19 @@ def _patch_loop(loop):
     def run_until_complete(self, future):
         self._check_closed()
         events._set_running_loop(self)
-        f = asyncio.ensure_future(future, loop=self)
-        if f is not future:
-            f._log_destroy_pending = False
-        while not f.done():
-            self._run_once()
-            if self._stopping:
-                break
-        if not f.done():
-            raise RuntimeError('Event loop stopped before Future completed.')
-        return f.result()
+        try:
+            f = asyncio.ensure_future(future, loop=self)
+            if f is not future:
+                f._log_destroy_pending = False
+            while not f.done():
+                self._run_once()
+                if self._stopping:
+                    break
+            if not f.done():
+                raise RuntimeError('Event loop stopped before Future completed.')
+            return f.result()
+        finally:
+            events._set_running_loop(None)
 
     def _run_once(self):
         """

--- a/tests/nest_test.py
+++ b/tests/nest_test.py
@@ -18,6 +18,7 @@ class NestTest(unittest.TestCase):
         self.loop.set_exception_handler(exception_handler)
 
     def tearDown(self):
+        self.assertIsNone(asyncio._get_running_loop())
         self.loop.close()
         del self.loop
 


### PR DESCRIPTION
I believe this reflects https://github.com/python/cpython/blob/374d998b507d34a6c0a3816a163926a8ba0c483f/Lib/asyncio/base_events.py#L602