### PR TITLE
set loop back when loop end

### DIFF
--- a/tests/nest_test.py
+++ b/tests/nest_test.py
@@ -18,6 +18,7 @@ class NestTest(unittest.TestCase):
         self.loop.set_exception_handler(exception_handler)
 
     def tearDown(self):
+        self.assertIsNone(asyncio._get_running_loop())
         self.loop.close()
         del self.loop
 


### PR DESCRIPTION
When running task with `run_until_complete` we
expect that when the loop is done there is not running
loop any more, as mentioned in PR https://github.com/erdewit/nest_asyncio/pull/25
, and it the reason of many issues https://github.com/erdewit/nest_asyncio/issues/27
https://github.com/erdewit/nest_asyncio/issues/24. 
However, we can not simply set the running to None as #25 .

Here, after the new loop is done, the running loop
is set back to the original one.