### PR TITLE
adding py 3.9 to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only
 
 [options]


### PR DESCRIPTION
guessing this should allow it to be picked up by https://pyreadiness.org/3.9/