### PR TITLE
expand test matrix to windows, macos and pypy-37

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,14 @@ on: [ push, pull_request ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        os: [ubuntu, macos, windows]
+        python-version: [ 3.6, 3.7, 3.8, 3.9, pypy-3.7 ]
+        exclude:
+          - os: windows
+            python-version: pypy-3.7
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Hi! Thanks for `nest_asyncio`!

This expands the test matrix to include the windows and macos platforms, as well as adding pypy-3.7.

The good news is it appears to work! :tada:

- https://github.com/bollwyvl/nest_asyncio/pull/1

The bad news is it isn't helping me unravel my downstream issues:

- https://github.com/conda-forge/ipykernel-feedstock/pull/84
  - https://github.com/ipython/ipykernel/pull/700
    - https://github.com/jupyter/jupyter_client/pull/663

It looks like we're running into some issues around `select` on an `EPollSelector`:

https://github.com/jupyter/jupyter_client/pull/663/checks?check_run_id=2954120077#step:6:1033

I'll do some more looking, but starting from a :green_circle: upstream is good!

Thanks again!