### PR TITLE
ENH: Use get_running_loop since get_event_loop is being deprecated

### DIFF
--- a/nest_asyncio.py
+++ b/nest_asyncio.py
@@ -9,7 +9,14 @@ from heapq import heappop
 
 def apply(loop=None):
     """Patch asyncio to make its event loop reentrant."""
-    loop = loop or asyncio.get_event_loop()
+    if loop is None:
+        if sys.version_info >= (3, 7, 0):
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+        else:
+            loop = asyncio.get_event_loop()
     if not isinstance(loop, asyncio.BaseEventLoop):
         raise ValueError('Can\'t patch loop of type %s' % type(loop))
     if getattr(loop, '_nest_patched', None):


### PR DESCRIPTION
According to Python 3.10's [doc](https://docs.python.org/3/library/asyncio-eventloop.html) for `asyncio.get_event_loop()`:

> Deprecated since version 3.10: Deprecation warning is emitted if there is no running event loop. In future Python releases, this function will be an alias of `get_running_loop()`.

Also, `get_running_loop` has been added since Python 3.7.