### PR TITLE
asyncio.run: close loops if we created them

### DIFF
--- a/tests/nest_test.py
+++ b/tests/nest_test.py
@@ -104,6 +104,18 @@ class NestTest(unittest.TestCase):
         result = self.loop.run_until_complete(coro())
         self.assertEqual(result, 42)
 
+    def test_run_close(self):
+        async def get_loop():
+            return asyncio.get_running_loop()
+        run_loop = asyncio.run(get_loop())
+        assert run_loop is not self.loop
+        assert run_loop._closed
+        assert not self.loop._closed
+        nested_run_loop = self.loop.run_until_complete(get_loop())
+        assert nested_run_loop is self.loop
+        assert not self.loop._closed
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/nest_test.py
+++ b/tests/nest_test.py
@@ -106,7 +106,7 @@ class NestTest(unittest.TestCase):
 
     def test_run_close(self):
         async def get_loop():
-            return asyncio.get_running_loop()
+            return asyncio.get_event_loop()
         run_loop = asyncio.run(get_loop())
         assert run_loop is not self.loop
         assert run_loop._closed


### PR DESCRIPTION
rather than leaving an open event loop, clean it up when we are done with it.

more closely matches asyncio.run behavior when run from outside an event loop.

This could be considered a breaking change, in that asyncio.run no longer re-uses an event loop when called from outside asyncio, but I _hope_ nobody is relying on creating something in one asyncio.run call and using it in another, since that's exactly what asyncio.run is meant to prevent.

An example script:

```python
import asyncio

# import nest_asyncio
# nest_asyncio.apply()

async def sleep_awhile():
    await asyncio.sleep(5)

async def show_tasks(step):
    asyncio.create_task(sleep_awhile(), name=f"sleep_while {step}")
    for task in asyncio.all_tasks():
        if task is not asyncio.current_task():
            print(task)

if __name__ == "__main__":
    for i in range(5):
        print(f"step {i}")
        asyncio.run(show_tasks(i))
```

- With unpatched asyncio.run, tasks created during the run call are cleaned up between asyncio.run calls.
- With nest_asyncio (without this patch), tasks created from one asyncio.run are still running, and accumulate from one run call to the next
- With this patch, nest_asyncio restores the behavior of asyncio.run when run outside an already running asyncio loop

Behavior should be unchanged for _reentrant_ calls to asyncio.run, but arguably something like a [TaskGroup](https://docs.python.org/3/library/asyncio-task.html#asyncio.TaskGroup) (or simpler: a check of `all_tasks`) could be used to cleanup any tasks created during a nested call to asyncio.run as well.

xref https://github.com/minrk/asyncio-atexit/issues/3 cc @jacobtomlinson 