### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,17 @@ name: nest_asyncio
 
 on: [ push, pull_request, workflow_dispatch ]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", pypy-3.9 ]
+        python-version: [ 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12", pypy-3.9 ]
         exclude:
           - os: ubuntu-latest
             python-version: 3.5
@@ -21,11 +25,12 @@ jobs:
             python-version: 3.6
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install dependencies
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
     Framework :: AsyncIO
 


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

Python 3.12.0 final is due out in two weeks: [2023-10-02](https://peps.python.org/pep-0693/).

See also https://dev.to/hugovk/help-test-python-312-beta-1508/